### PR TITLE
Fixed up type definition for Record Type

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2440,7 +2440,7 @@ declare module Immutable {
 
     // Reading values
 
-    has(key: string): key is keyof TProps;
+    has(key: string | number | Symbol): key is keyof TProps;
 
     /**
      * Returns the value associated with the provided key, which may be the


### PR DESCRIPTION
Type needs to be union type of `string | number | Symbol` and not just `string`